### PR TITLE
PREFIX has to be specified twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Installation
 ------------
 
 ```sh
-make
+make PREFIX=/usr
 make PREFIX=/usr install # will overwrite existing udev libraries if any
 # rebuild all packages which depends on udev
 # here we go !


### PR DESCRIPTION
`PREFIX` has to be specified when using `make` solely. This is done to correct the wrong paths inside the generated `libudev.pc` which will always be `/usr/local/{include,lib}` regardless of the `PREFIX` value passed to `make install`.