### PR TITLE
fix build with older kernel headers

### DIFF
--- a/udev_device.c
+++ b/udev_device.c
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <sys/stat.h>
 #include <linux/input.h>
+#include <linux/input-event-codes.h>
 
 #include "udev.h"
 #include "udev_list.h"


### PR DESCRIPTION
with kernel-headers 3.12.6:

```
udev_device.c: In function 'udev_device_set_properties_from_evdev':
udev_device.c:418:39: error: 'INPUT_PROP_POINTING_STICK' undeclared (first use in this function)
     if (find_bit(prop_bits, prop_cnt, INPUT_PROP_POINTING_STICK)) {
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
udev_device.c:418:39: note: each undeclared identifier is reported only once for each function it appears in
udev_device.c:422:39: error: 'INPUT_PROP_ACCELEROMETER' undeclared (first use in this function)
     if (find_bit(prop_bits, prop_cnt, INPUT_PROP_ACCELEROMETER)) {
                                       ^~~~~~~~~~~~~~~~~~~~~~~~
make: *** [udev_device.o] Error 1
```