### PR TITLE
Add dummy udev_device_get_usec_since_initialized() impl

### DIFF
--- a/udev.h
+++ b/udev.h
@@ -22,6 +22,7 @@ struct udev *udev_new(void);
 struct udev *udev_ref(struct udev *udev);
 struct udev *udev_unref(struct udev *udev);
 
+unsigned long long udev_device_get_usec_since_initialized(struct udev_device *udev_device);
 const char *udev_device_get_syspath(struct udev_device *udev_device);
 const char *udev_device_get_sysname(struct udev_device *udev_device);
 const char *udev_device_get_sysnum(struct udev_device *udev_device);

--- a/udev_device.c
+++ b/udev_device.c
@@ -19,6 +19,11 @@ struct udev_device {
     int refcount;
 };
 
+unsigned long long udev_device_get_usec_since_initialized(struct udev_device *udev_device)
+{
+    return 0ull;
+}
+
 const char *udev_device_get_syspath(struct udev_device *udev_device)
 {
     return udev_device_get_property_value(udev_device, "SYSPATH");


### PR DESCRIPTION
Just adds a dummy impl for `udev_device_get_usec_since_initialized()` which returns 0. After adding this call my machine can successfully run `libinput list-devices`.

Closes #12 