### PR TITLE
Add missing udev log functions

### DIFF
--- a/udev.c
+++ b/udev.c
@@ -43,3 +43,19 @@ struct udev *udev_unref(struct udev *udev)
     free(udev);
     return NULL;
 }
+
+void udev_set_log_fn(struct udev *udev,
+                            void (*log_fn)(struct udev *udev,
+                                           int priority, const char *file, int line, const char *fn,
+                                           const char *format, va_list args))
+{
+}
+
+int udev_get_log_priority(struct udev *udev)
+{
+    return 0;
+}
+
+void udev_set_log_priority(struct udev *udev, int priority)
+{
+}

--- a/udev.h
+++ b/udev.h
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <sys/sysmacros.h>
+#include <stdarg.h>
 
 #ifndef _LIBUDEV_H_
 #define _LIBUDEV_H_
@@ -21,6 +22,13 @@ struct udev_list_entry;
 struct udev *udev_new(void);
 struct udev *udev_ref(struct udev *udev);
 struct udev *udev_unref(struct udev *udev);
+
+void udev_set_log_fn(struct udev *udev,
+                            void (*log_fn)(struct udev *udev,
+                                           int priority, const char *file, int line, const char *fn,
+                                           const char *format, va_list args));
+int udev_get_log_priority(struct udev *udev);
+void udev_set_log_priority(struct udev *udev, int priority);
 
 const char *udev_device_get_syspath(struct udev_device *udev_device);
 const char *udev_device_get_sysname(struct udev_device *udev_device);


### PR DESCRIPTION
Without these functions Chromium and Electron crash during
startup with a SIGTRAP while loading libudev.