### PR TITLE
Treat devices with keys as keyboards

### DIFF
--- a/udev_device.c
+++ b/udev_device.c
@@ -461,7 +461,8 @@ static void udev_device_set_properties_from_evdev(struct udev_device *udev_devic
             }
         }
     }
-    else if (find_bit(ev_bits, ev_cnt, EV_KEY)) {
+
+    if (find_bit(ev_bits, ev_cnt, EV_KEY)) {
         udev_list_entry_add(&udev_device->properties, "ID_INPUT_KEY", "1", 0);
 
         if (find_bit(key_bits, key_cnt, KEY_ENTER)) {


### PR DESCRIPTION
Some keyboards have an absolute axis and would erroneously not be treated
as a keyboard. Now any device with keys would have the ID_INPUT_KEY
property set.

So I have a keyboard where the multimedia keys are treated as a separate input device. This device has a volume slider which apparently has an absolute axis. Given the mutual exclusion between devices with axis and keyboards the device was left unlabeled and unrecognized by X. The patch removes said exclusion. 

So with this patch it is theoretically possible for a device to have both the keyboard property and some pointer property. Don't know what device that would be, but if it was a concern can just rearrange the if/else statement so that the keyboard check comes first