### PR TITLE
Continue to monitor events even after epoll_wait is interrupted by a signal

### DIFF
--- a/udev_monitor.c
+++ b/udev_monitor.c
@@ -120,7 +120,10 @@ static void *udev_monitor_handle_event(void *ptr)
     ssize_t len;
     int i;
 
-    while (epoll_wait(udev_monitor->efd, epoll, 2, -1) != -1) {
+    while (1) {
+        if(epoll_wait(udev_monitor->efd, epoll, 2, -1) == -1) {
+            continue;
+        }
         for (i = 0; i < 2; i++) {
             if (epoll[i].data.fd != udev_monitor->pfd[0]) {
                 continue;


### PR DESCRIPTION
In udev_monitor_handle_event we spun in a loop. One of the exit
conditions was epoll_wait erroring. However, it could error in harmless
ways that shouldn't cause termination like when errno == EINTR. Now
epoll_wait errors are ignored.

Resolves #23