### PR TITLE
Remove epoll dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Thankfully `udev` has stable API and hopefully no changes will be made to it the
 * C99 compiler (build time)
 * POSIX make (build time)
 * POSIX & XSI libc
-* epoll & inotify
+* inotify
 * Linux >= 2.6.39
 
 ## Installation


### PR DESCRIPTION
Instead of using the Linux-specific epoll, we can use the
more portable poll.

So as far as I can tell #23 isn't fixed. This commit also has the side effect of addressing that