### PR TITLE
Fix install error at make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ libudev.pc: libudev.pc.in
 		-e 's|@VERSION@|243|g' \
 		libudev.pc.in > libudev.pc
 
-install: libudev.so libudev.a libudev.pc
+install: libudev.so.1 libudev.a libudev.pc
 	mkdir -p         ${DESTDIR}${INCLUDEDIR} ${DESTDIR}${LIBDIR} ${DESTDIR}${PKGCONFIGDIR}
 	cp -f udev.h  	 ${DESTDIR}${INCLUDEDIR}/libudev.h
 	cp -f libudev.a  ${DESTDIR}${LIBDIR}/libudev.a


### PR DESCRIPTION
At db72f8610d62a5e6884c6d8d86660d07e49455c4 is missing change in Makefile.
This err was reporting at bkuhls.
This patch fix it.