### PR TITLE
Add .clang-format and reformat

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,178 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Microsoft
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      false
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -32,18 +32,18 @@ BinPackParameters: true
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      true
-  AfterControlStatement: Always
+  AfterControlStatement: Never
   AfterEnum:       true
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: true
-  AfterStruct:     true
+  AfterStruct:     false
   AfterUnion:      false
   AfterExternBlock: true
   BeforeCatch:     true
   BeforeElse:      true
   BeforeLambdaBody: false
-  BeforeWhile:     false
+  BeforeWhile:     true
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
@@ -58,7 +58,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     120
+ColumnLimit:     0
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
@@ -99,7 +99,7 @@ IndentCaseLabels: false
 IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentExternBlock: AfterExternBlock
+IndentExternBlock: NoIndent
 IndentRequires:  false
 IndentWidth:     4
 IndentWrappedFunctionNames: false

--- a/.clang-format
+++ b/.clang-format
@@ -174,5 +174,6 @@ WhitespaceSensitiveMacros:
   - BOOST_PP_STRINGIZE
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
+Cpp11BracedListStyle: false
 ...
 

--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@
 Language:        Cpp
 # BasedOnStyle:  Microsoft
 AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: AlwaysBreak
 AlignArrayOfStructures: None
 AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
@@ -13,7 +13,7 @@ AlignOperands:   Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortEnumsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
@@ -28,7 +28,7 @@ AlwaysBreakTemplateDeclarations: MultiLine
 AttributeMacros:
   - __capability
 BinPackArguments: true
-BinPackParameters: true
+BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      true
@@ -58,7 +58,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     0
+ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false

--- a/udev.c
+++ b/udev.c
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2020-2021 illiliti <illiliti@protonmail.com>
  * SPDX-License-Identifier: ISC
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -62,8 +62,8 @@ struct udev *udev_unref(struct udev *udev)
 }
 
 void udev_set_log_fn(struct udev *udev, void (*log_fn)(struct udev *udev,
-            int priority, const char *file, int line, const char *fn,
-            const char *format, va_list args))
+                                                       int priority, const char *file, int line, const char *fn,
+                                                       const char *format, va_list args))
 {
 }
 

--- a/udev.c
+++ b/udev.c
@@ -61,9 +61,16 @@ struct udev *udev_unref(struct udev *udev)
     return NULL;
 }
 
-void udev_set_log_fn(struct udev *udev, void (*log_fn)(struct udev *udev,
-                                                       int priority, const char *file, int line, const char *fn,
-                                                       const char *format, va_list args))
+void udev_set_log_fn(
+    struct udev *udev,
+    void (*log_fn)(
+        struct udev *udev,
+        int priority,
+        const char *file,
+        int line,
+        const char *fn,
+        const char *format,
+        va_list args))
 {
 }
 
@@ -91,7 +98,10 @@ int udev_get_log_priority(struct udev *udev)
     return NULL;
 }
 
-/* XXX NOT IMPLEMENTED */ struct udev_list_entry *udev_hwdb_get_properties_list_entry(struct udev_hwdb *hwdb, const char *modalias, unsigned int flags)
+/* XXX NOT IMPLEMENTED */ struct udev_list_entry *udev_hwdb_get_properties_list_entry(
+    struct udev_hwdb *hwdb,
+    const char *modalias,
+    unsigned int flags)
 {
     return NULL;
 }

--- a/udev.h
+++ b/udev.h
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2020-2021 illiliti <illiliti@protonmail.com>
  * SPDX-License-Identifier: ISC
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -44,8 +44,8 @@ struct udev *udev_ref(struct udev *udev);
 struct udev *udev_unref(struct udev *udev);
 
 void udev_set_log_fn(struct udev *udev, void (*log_fn)(struct udev *udev,
-            int priority, const char *file, int line, const char *fn,
-            const char *format, va_list args));
+                                                       int priority, const char *file, int line, const char *fn,
+                                                       const char *format, va_list args));
 void udev_set_log_priority(struct udev *udev, int priority);
 int udev_get_log_priority(struct udev *udev);
 

--- a/udev.h
+++ b/udev.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif
 
-#define udev_list_entry_foreach(list_entry, first_entry) \
+#define udev_list_entry_foreach(list_entry, first_entry)                                                               \
     for (list_entry = first_entry; list_entry; list_entry = udev_list_entry_get_next(list_entry))
 
 struct udev;
@@ -43,9 +43,16 @@ struct udev *udev_new(void);
 struct udev *udev_ref(struct udev *udev);
 struct udev *udev_unref(struct udev *udev);
 
-void udev_set_log_fn(struct udev *udev, void (*log_fn)(struct udev *udev,
-                                                       int priority, const char *file, int line, const char *fn,
-                                                       const char *format, va_list args));
+void udev_set_log_fn(
+    struct udev *udev,
+    void (*log_fn)(
+        struct udev *udev,
+        int priority,
+        const char *file,
+        int line,
+        const char *fn,
+        const char *format,
+        va_list args));
 void udev_set_log_priority(struct udev *udev, int priority);
 int udev_get_log_priority(struct udev *udev);
 
@@ -62,7 +69,10 @@ const char *udev_device_get_subsystem(struct udev_device *udev_device);
 const char *udev_device_get_driver(struct udev_device *udev_device);
 struct udev *udev_device_get_udev(struct udev_device *udev_device);
 struct udev_device *udev_device_get_parent(struct udev_device *udev_device);
-struct udev_device *udev_device_get_parent_with_subsystem_devtype(struct udev_device *udev_device, const char *subsystem, const char *devtype);
+struct udev_device *udev_device_get_parent_with_subsystem_devtype(
+    struct udev_device *udev_device,
+    const char *subsystem,
+    const char *devtype);
 int udev_device_get_is_initialized(struct udev_device *udev_device);
 const char *udev_device_get_action(struct udev_device *udev_device);
 
@@ -77,7 +87,10 @@ int udev_device_set_sysattr_value(struct udev_device *udev_device, const char *s
 
 struct udev_device *udev_device_new_from_syspath(struct udev *udev, const char *syspath);
 struct udev_device *udev_device_new_from_devnum(struct udev *udev, char type, dev_t devnum);
-struct udev_device *udev_device_new_from_subsystem_sysname(struct udev *udev, const char *subsystem, const char *sysname);
+struct udev_device *udev_device_new_from_subsystem_sysname(
+    struct udev *udev,
+    const char *subsystem,
+    const char *sysname);
 struct udev_device *udev_device_new_from_device_id(struct udev *udev, const char *id);
 struct udev_device *udev_device_new_from_environment(struct udev *udev);
 struct udev_device *udev_device_ref(struct udev_device *udev_device);
@@ -116,7 +129,10 @@ struct udev *udev_monitor_get_udev(struct udev_monitor *udev_monitor);
 
 int udev_monitor_filter_update(struct udev_monitor *udev_monitor);
 int udev_monitor_filter_remove(struct udev_monitor *udev_monitor);
-int udev_monitor_filter_add_match_subsystem_devtype(struct udev_monitor *udev_monitor, const char *subsystem, const char *devtype);
+int udev_monitor_filter_add_match_subsystem_devtype(
+    struct udev_monitor *udev_monitor,
+    const char *subsystem,
+    const char *devtype);
 int udev_monitor_filter_add_match_tag(struct udev_monitor *udev_monitor, const char *tag);
 
 struct udev_monitor *udev_monitor_new_from_netlink(struct udev *udev, const char *name);
@@ -126,7 +142,10 @@ struct udev_monitor *udev_monitor_unref(struct udev_monitor *udev_monitor);
 struct udev_hwdb *udev_hwdb_new(struct udev *udev);
 struct udev_hwdb *udev_hwdb_ref(struct udev_hwdb *hwdb);
 struct udev_hwdb *udev_hwdb_unref(struct udev_hwdb *hwdb);
-struct udev_list_entry *udev_hwdb_get_properties_list_entry(struct udev_hwdb *hwdb, const char *modalias, unsigned int flags);
+struct udev_list_entry *udev_hwdb_get_properties_list_entry(
+    struct udev_hwdb *hwdb,
+    const char *modalias,
+    unsigned int flags);
 
 // this is "libudev-zero" extension. do not use if portability is concern
 struct udev_device *udev_device_new_from_uevent(struct udev *udev, char *buf, size_t len);

--- a/udev_device.c
+++ b/udev_device.c
@@ -400,11 +400,11 @@ static int test_bit(unsigned long *arr, unsigned long bit)
 static void set_properties_from_evdev(struct udev_device *udev_device)
 {
     // https://kernel.org/doc/html/latest/driver-api/input.html#c.input_dev
-    unsigned long prop_bits[BITS_TO_LONGS(INPUT_PROP_CNT)] = {0};
-    unsigned long abs_bits[BITS_TO_LONGS(ABS_CNT)] = {0};
-    unsigned long rel_bits[BITS_TO_LONGS(REL_CNT)] = {0};
-    unsigned long key_bits[BITS_TO_LONGS(KEY_CNT)] = {0};
-    unsigned long ev_bits[BITS_TO_LONGS(EV_CNT)] = {0};
+    unsigned long prop_bits[BITS_TO_LONGS(INPUT_PROP_CNT)] = { 0 };
+    unsigned long abs_bits[BITS_TO_LONGS(ABS_CNT)] = { 0 };
+    unsigned long rel_bits[BITS_TO_LONGS(REL_CNT)] = { 0 };
+    unsigned long key_bits[BITS_TO_LONGS(KEY_CNT)] = { 0 };
+    unsigned long ev_bits[BITS_TO_LONGS(EV_CNT)] = { 0 };
     struct udev_device *parent;
     const char *subsystem;
     unsigned long bit;
@@ -618,7 +618,7 @@ struct udev_device *udev_device_new_from_subsystem_sysname(
     const char *subsystem,
     const char *sysname)
 {
-    const char *fmt[] = {"/sys/bus/%s/devices/%s", "/sys/class/%s/%s", NULL};
+    const char *fmt[] = { "/sys/bus/%s/devices/%s", "/sys/class/%s/%s", NULL };
     char path[PATH_MAX];
     int i;
 

--- a/udev_device.c
+++ b/udev_device.c
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2020-2021 illiliti <illiliti@protonmail.com>
  * SPDX-License-Identifier: ISC
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -15,13 +15,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <string.h>
-#include <stdlib.h>
 #include <limits.h>
-#include <sys/stat.h>
 #include <linux/input.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "udev.h"
 #include "udev_list.h"
@@ -613,7 +613,7 @@ struct udev_device *udev_device_new_from_devnum(struct udev *udev, char type, de
 
 struct udev_device *udev_device_new_from_subsystem_sysname(struct udev *udev, const char *subsystem, const char *sysname)
 {
-    const char *fmt[] = { "/sys/bus/%s/devices/%s", "/sys/class/%s/%s", NULL };
+    const char *fmt[] = {"/sys/bus/%s/devices/%s", "/sys/class/%s/%s", NULL};
     char path[PATH_MAX];
     int i;
 
@@ -654,7 +654,7 @@ struct udev_device *udev_device_new_from_uevent(struct udev *udev, char *buf, si
     udev_list_entry_init(&udev_device->sysattrs);
 
     for (end = buf + len; buf < end; buf += strlen(buf) + 1) {
-       if (strncmp(buf, "DEVPATH=", 8) == 0) {
+        if (strncmp(buf, "DEVPATH=", 8) == 0) {
             snprintf(syspath, sizeof(syspath), "/sys%s", buf + 8);
             udev_list_entry_add(&udev_device->properties, "SYSPATH", syspath, 0);
             udev_list_entry_add(&udev_device->properties, "DEVPATH", buf + 8, 0);

--- a/udev_device.c
+++ b/udev_device.c
@@ -169,7 +169,10 @@ struct udev_device *udev_device_get_parent(struct udev_device *udev_device)
     return udev_device->parent;
 }
 
-struct udev_device *udev_device_get_parent_with_subsystem_devtype(struct udev_device *udev_device, const char *subsystem, const char *devtype)
+struct udev_device *udev_device_get_parent_with_subsystem_devtype(
+    struct udev_device *udev_device,
+    const char *subsystem,
+    const char *devtype)
 {
     const char *parent_subsystem, *parent_devtype;
     struct udev_device *parent;
@@ -447,14 +450,13 @@ static void set_properties_from_evdev(struct udev_device *udev_device)
     }
 
     if (test_bit(ev_bits, EV_REL)) {
-        if (test_bit(rel_bits, REL_Y) && test_bit(rel_bits, REL_X) &&
-            test_bit(key_bits, BTN_MOUSE)) {
+        if (test_bit(rel_bits, REL_Y) && test_bit(rel_bits, REL_X) && test_bit(key_bits, BTN_MOUSE)) {
             udev_list_entry_add(&udev_device->properties, "ID_INPUT_MOUSE", "1", 0);
         }
     }
     else if (test_bit(ev_bits, EV_ABS)) {
-        if (test_bit(key_bits, BTN_SELECT) || test_bit(key_bits, BTN_TR) ||
-            test_bit(key_bits, BTN_START) || test_bit(key_bits, BTN_TL)) {
+        if (test_bit(key_bits, BTN_SELECT) || test_bit(key_bits, BTN_TR) || test_bit(key_bits, BTN_START) ||
+            test_bit(key_bits, BTN_TL)) {
             if (test_bit(key_bits, BTN_TOUCH)) {
                 udev_list_entry_add(&udev_device->properties, "ID_INPUT_TOUCHSCREEN", "1", 0);
             }
@@ -611,7 +613,10 @@ struct udev_device *udev_device_new_from_devnum(struct udev *udev, char type, de
     return udev_device_new_from_syspath(udev, path);
 }
 
-struct udev_device *udev_device_new_from_subsystem_sysname(struct udev *udev, const char *subsystem, const char *sysname)
+struct udev_device *udev_device_new_from_subsystem_sysname(
+    struct udev *udev,
+    const char *subsystem,
+    const char *sysname)
 {
     const char *fmt[] = {"/sys/bus/%s/devices/%s", "/sys/class/%s/%s", NULL};
     char path[PATH_MAX];
@@ -684,9 +689,7 @@ struct udev_device *udev_device_new_from_uevent(struct udev *udev, char *buf, si
 
             *pos = '\0';
 
-            if (strcmp(buf, "SUBSYSTEM") == 0 ||
-                strcmp(buf, "ACTION") == 0 ||
-                strcmp(buf, "SEQNUM") == 0) {
+            if (strcmp(buf, "SUBSYSTEM") == 0 || strcmp(buf, "ACTION") == 0 || strcmp(buf, "SEQNUM") == 0) {
                 cnt++;
             }
 

--- a/udev_enumerate.c
+++ b/udev_enumerate.c
@@ -330,7 +330,7 @@ free_de:
 
 int udev_enumerate_scan_devices(struct udev_enumerate *udev_enumerate)
 {
-    const char *path[] = {"/sys/dev/block", "/sys/dev/char", NULL};
+    const char *path[] = { "/sys/dev/block", "/sys/dev/char", NULL };
     int i;
 
     if (!udev_enumerate) {

--- a/udev_enumerate.c
+++ b/udev_enumerate.c
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2020-2021 illiliti <illiliti@protonmail.com>
  * SPDX-License-Identifier: ISC
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -15,13 +15,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <dirent.h>
+#include <fnmatch.h>
+#include <limits.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <dirent.h>
 #include <string.h>
-#include <limits.h>
-#include <fnmatch.h>
-#include <pthread.h>
 
 #include "udev.h"
 #include "udev_list.h"
@@ -330,7 +330,7 @@ free_de:
 
 int udev_enumerate_scan_devices(struct udev_enumerate *udev_enumerate)
 {
-    const char *path[] = { "/sys/dev/block", "/sys/dev/char", NULL };
+    const char *path[] = {"/sys/dev/block", "/sys/dev/char", NULL};
     int i;
 
     if (!udev_enumerate) {

--- a/udev_enumerate.c
+++ b/udev_enumerate.c
@@ -80,7 +80,9 @@ int udev_enumerate_add_match_sysname(struct udev_enumerate *udev_enumerate, cons
     return 0;
 }
 
-/* XXX NOT IMPLEMENTED */ int udev_enumerate_add_match_parent(struct udev_enumerate *udev_enumerate, struct udev_device *parent)
+/* XXX NOT IMPLEMENTED */ int udev_enumerate_add_match_parent(
+    struct udev_enumerate *udev_enumerate,
+    struct udev_device *parent)
 {
     return 0;
 }
@@ -179,8 +181,7 @@ static int filter_property(struct udev_enumerate *udev_enumerate, struct udev_de
                 continue;
             }
 
-            if (fnmatch(property, property2, 0) == 0 &&
-                fnmatch(value, value2, 0) == 0) {
+            if (fnmatch(property, property2, 0) == 0 && fnmatch(value, value2, 0) == 0) {
                 return 1;
             }
 
@@ -251,8 +252,7 @@ static void *add_device(void *ptr)
     }
 
     if (!filter_subsystem(thread->udev_enumerate, udev_device) ||
-        !filter_sysname(thread->udev_enumerate, udev_device) ||
-        !filter_property(thread->udev_enumerate, udev_device) ||
+        !filter_sysname(thread->udev_enumerate, udev_device) || !filter_property(thread->udev_enumerate, udev_device) ||
         !filter_sysattr(thread->udev_enumerate, udev_device)) {
         udev_device_unref(udev_device);
         return NULL;

--- a/udev_list.c
+++ b/udev_list.c
@@ -46,7 +46,11 @@ void udev_list_entry_free_all(struct udev_list_entry *list_entry)
     }
 }
 
-struct udev_list_entry *udev_list_entry_add(struct udev_list_entry *list_entry, const char *name, const char *value, int uniq)
+struct udev_list_entry *udev_list_entry_add(
+    struct udev_list_entry *list_entry,
+    const char *name,
+    const char *value,
+    int uniq)
 {
     struct udev_list_entry *list_entry2;
 

--- a/udev_list.c
+++ b/udev_list.c
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2020-2021 illiliti <illiliti@protonmail.com>
  * SPDX-License-Identifier: ISC
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -15,8 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "udev.h"
 #include "udev_list.h"

--- a/udev_list.h
+++ b/udev_list.h
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2020-2021 illiliti <illiliti@protonmail.com>
  * SPDX-License-Identifier: ISC
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR

--- a/udev_list.h
+++ b/udev_list.h
@@ -24,4 +24,8 @@ struct udev_list_entry {
 void udev_list_entry_init(struct udev_list_entry *list_entry);
 void udev_list_entry_free(struct udev_list_entry *list_entry);
 void udev_list_entry_free_all(struct udev_list_entry *list_entry);
-struct udev_list_entry *udev_list_entry_add(struct udev_list_entry *list_entry, const char *name, const char *value, int uniq);
+struct udev_list_entry *udev_list_entry_add(
+    struct udev_list_entry *list_entry,
+    const char *name,
+    const char *value,
+    int uniq);

--- a/udev_monitor.c
+++ b/udev_monitor.c
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2020-2021 illiliti <illiliti@protonmail.com>
  * SPDX-License-Identifier: ISC
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -15,11 +15,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <string.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <sys/socket.h>
 #include <linux/netlink.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include "udev.h"
 #include "udev_list.h"

--- a/udev_monitor.c
+++ b/udev_monitor.c
@@ -94,9 +94,9 @@ static int filter_subsystem(struct udev_monitor *udev_monitor, struct udev_devic
 struct udev_device *udev_monitor_receive_device(struct udev_monitor *udev_monitor)
 {
     struct udev_device *udev_device;
-    struct sockaddr_nl sa = {0};
-    struct msghdr hdr = {0};
-    struct iovec iov = {0};
+    struct sockaddr_nl sa = { 0 };
+    struct msghdr hdr = { 0 };
+    struct iovec iov = { 0 };
     char buf[8192];
     ssize_t len;
 
@@ -142,7 +142,7 @@ struct udev_device *udev_monitor_receive_device(struct udev_monitor *udev_monito
 
 int udev_monitor_enable_receiving(struct udev_monitor *udev_monitor)
 {
-    struct sockaddr_nl sa = {0};
+    struct sockaddr_nl sa = { 0 };
 
     if (!udev_monitor) {
         return -1;

--- a/udev_monitor.c
+++ b/udev_monitor.c
@@ -129,8 +129,7 @@ struct udev_device *udev_monitor_receive_device(struct udev_monitor *udev_monito
             continue;
         }
 
-        if (!filter_subsystem(udev_monitor, udev_device) ||
-            !filter_devtype(udev_monitor, udev_device)) {
+        if (!filter_subsystem(udev_monitor, udev_device) || !filter_devtype(udev_monitor, udev_device)) {
             udev_device_unref(udev_device);
             continue;
         }
@@ -179,7 +178,10 @@ struct udev *udev_monitor_get_udev(struct udev_monitor *udev_monitor)
     return 0;
 }
 
-int udev_monitor_filter_add_match_subsystem_devtype(struct udev_monitor *udev_monitor, const char *subsystem, const char *devtype)
+int udev_monitor_filter_add_match_subsystem_devtype(
+    struct udev_monitor *udev_monitor,
+    const char *subsystem,
+    const char *devtype)
 {
     if (!udev_monitor || !subsystem) {
         return -1;


### PR DESCRIPTION
libudev-zero is not defined coding-style. This pull request add to coding-style information using clang-format.
This .clang-format is not match existing coding style completely.   When this pull request will apply, few code will change.

If libudev-zero define coding style, it will support code contribution.