### PR TITLE
Fix undefined LINE_MAX on Android

### DIFF
--- a/udev_device.c
+++ b/udev_device.c
@@ -26,6 +26,10 @@
 #include "udev.h"
 #include "udev_list.h"
 
+#ifndef LINE_MAX
+#define LINE_MAX 2048
+#endif
+
 #ifndef LONG_BIT
 #define LONG_BIT (sizeof(unsigned long) * 8)
 #endif


### PR DESCRIPTION
I'm working on building [libfido2 for different platforms](https://github.com/Yubico/libfido2/issues/247), and while I have no idea if it's going to work on Android, I'm giving libudev-zero a try. The only compilation issue I faced was LINE_MAX being undefined, so I just added an ifndef for it, and use 2048 which is the value I have on Linux.