### PR TITLE
Avoidable OOM on small systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PREFIX = /usr/local
 LIBDIR = ${PREFIX}/lib
 INCLUDEDIR = ${PREFIX}/include
 PKGCONFIGDIR = ${LIBDIR}/pkgconfig
-XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -fPIC -pthread -D_XOPEN_SOURCE=700 \
+XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -fPIC -D_XOPEN_SOURCE=700 \
 		  -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wstrict-prototypes \
 		  -Wno-unused-parameter
 XLDFLAGS = ${LDFLAGS} -shared -Wl,-soname,libudev.so.1

--- a/libudev.pc.in
+++ b/libudev.pc.in
@@ -9,5 +9,4 @@ Description: Daemonless replacement for libudev
 Version: @VERSION@
 URL: https://github.com/illiliti/libudev-zero
 Libs: -L${libdir} -ludev
-Libs.private: -pthread
 Cflags: -I${includedir}

--- a/udev_enumerate.c
+++ b/udev_enumerate.c
@@ -291,14 +291,7 @@ static int scan_devices(struct udev_enumerate *udev_enumerate, const char *path)
 
         snprintf(thread[i].path, sizeof(thread[i].path), "%s/%s", path, de[i]->d_name);
 
-        if (pthread_create(&thread[i].thread, NULL, add_device, &thread[i]) != 0) {
-            ret = 0;
-            break;
-        }
-    }
-
-    for (i = 0; i < cnt; i++) {
-        pthread_join(thread[i].thread, NULL);
+        add_device(&thread[i]);
     }
 
     free(thread);


### PR DESCRIPTION
Thanks for your good work.

I am using this on a f1c100s with 32 MB of RAM. The OOM killer kills my program and I traced the cause to the creation of 619 threads in `scan_devices` - one thread for each entry in `/sys/dev/char`. I was able to solve the problem by simply calling `add_device` synchronously in the loop instead of spawning threads.

The first commit fixes the problem. The second commit refactors the change (doesn't allocate the `thread` array, which also contributed to the OOM since it allocates 619 structs each with a `PATH_MAX` length array. 619*4096=2.5MB).

Is this parallelized so that the enumeration happens nearly simultaneously/atomically? I don't have enough context to know if that's crucial. If it is, maybe there's another POSIX strategy available to achieve it? If it's parallelized just for performance reasons, I found execution time after the change to be acceptable (0.7s, see below).

I don't think it's unreasonable to expect people to try to use this library on such small systems. systemd+udev is too big for my system and I was able to get the functionality I needed here. I think others will discover this replacement the same way.

Instead of my changes, maybe the threads could be batched up to 64 threads? Or a config option to use the synchronous version?

One more thing. I occasionally saw a segfault failure instead of OOM. I think this happened because the OS decided not to over-allocate for some executions and OOM would not trigger, but the failed allocation / thread creation wasn't handled correctly somewhere in the code.

```
# free -h
              total        used        free      shared  buff/cache   available
Mem:          22.8M        7.0M        9.6M       36.0K        6.2M       13.4M
Swap:             0           0           0
# ./usbip_crashes_ee32ac5f6494047b9ece26e7a5920650cdf46655
usage: usbip [--debug] [--log] [--tcp-port PORT] [version]
             [help] <command> <args>
 
  attach     Attach a remote USB device
  detach     Detach a remote USB device
  list       List exportable or local USB devices
  bind       Bind device to usbip-host.ko
  unbind     Unbind device from usbip-host.ko
  port       Show imported USB devices
 
# ./usbip_crashes_ee32ac5f6494047b9ece26e7a5920650cdf46655 list -l
usbip: error: failed to open /usr/share/hwdata/usb.ids
[   88.815400] usbip_crashes_e invoked oom-killer: gfp_mask=0x100cca(GFP_HIGHUSER_MOVABLE), order=0, oom_score_adj=0
[   88.849760] CPU: 0 PID: 462 Comm: usbip_crashes_e Not tainted 5.11.0-licheepi-nano #1
[   88.869960] Hardware name: Allwinner suniv Family
[   88.886886] [<c010ca40>] (unwind_backtrace) from [<c010a0ac>] (show_stack+0x10/0x14)
[   88.907269] [<c010a0ac>] (show_stack) from [<c0685f9c>] (dump_header+0x50/0x200)
[   88.927595] [<c0685f9c>] (dump_header) from [<c01a29fc>] (oom_kill_process+0x408/0x438)
[   88.948685] [<c01a29fc>] (oom_kill_process) from [<c01a31d0>] (out_of_memory+0x1c0/0x4c0)
[   88.970101] [<c01a31d0>] (out_of_memory) from [<c01dd61c>] (__alloc_pages_nodemask+0x9a4/0xccc)
[   88.992480] [<c01dd61c>] (__alloc_pages_nodemask) from [<c01a0064>] (pagecache_get_page+0xe4/0x314)
[   89.028840] [<c01a0064>] (pagecache_get_page) from [<c01a1124>] (filemap_fault+0x5c0/0x92c)
[   89.051462] [<c01a1124>] (filemap_fault) from [<c01c424c>] (__do_fault+0x38/0x14c)
[   89.073609] [<c01c424c>] (__do_fault) from [<c01c8c3c>] (handle_mm_fault+0x864/0xc24)
[   89.096243] [<c01c8c3c>] (handle_mm_fault) from [<c010d32c>] (do_page_fault+0x120/0x2e0)
[   89.119376] [<c010d32c>] (do_page_fault) from [<c010d77c>] (do_PrefetchAbort+0x38/0x8c)
[   89.142466] [<c010d77c>] (do_PrefetchAbort) from [<c0101744>] (ret_from_exception+0x0/0x1c)
[   89.165942] Exception stack(0xc1af7fb0 to 0xc1af7ff8)
[   89.185998] 7fa0:                                     b6d06168 baf96d94 00001000 00000000
[   89.209461] 7fc0: ffffffff baf96d94 004c02d0 00000000 be947a2a ba79a000 baf96da0 baf99f1c
[   89.232910] 7fe0: 004bef14 baf96588 004ab2bc b6ee5b30 20000010 ffffffff
[   89.254752] Mem-Info:
[   89.272107] active_anon:14 inactive_anon:2723 isolated_anon:0
[   89.272107]  active_file:1 inactive_file:38 isolated_file:0
[   89.272107]  unevictable:0 dirty:0 writeback:0
[   89.272107]  slab_reclaimable:214 slab_unreclaimable:1025
[   89.272107]  mapped:9 shmem:9 pagetables:393 bounce:0
[   89.272107]  free:736 free_pcp:0 free_cma:0
[   89.393138] Node 0 active_anon:56kB inactive_anon:10892kB active_file:4kB inactive_file:152kB unevictable:0kB isolated(anon):0kB isolated(file):0kB mapped:36kB dirty:0kB writeback:0kB shmem:36kB writeback_tmp:0kB kernel_stack:288kB pagetables:1572kB all_unreclaimable? no
[   89.464555] Normal free:2944kB min:4692kB low:4840kB high:4988kB reserved_highatomic:0KB active_anon:56kB inactive_anon:10892kB active_file:4kB inactive_file:152kB unevictable:0kB writepending:0kB present:32768kB managed:23300kB mlocked:0kB bounce:0kB free_pcp:0kB local_pcp:0kB free_cma:0kB
[   89.538798] lowmem_reserve[]: 0 0 0
[   89.558537] Normal: 44*4kB (UM) 8*8kB (M) 7*16kB (M) 1*32kB (M) 0*64kB 0*128kB 0*256kB 1*512kB (M) 0*1024kB 1*2048kB (M) 0*4096kB = 2944kB
[   89.604128] 48 total pagecache pages
[   89.623909] 0 pages in swap cache
[   89.643074] Swap cache stats: add 0, delete 0, find 0/0
[   89.663922] Free swap  = 0kB
[   89.681894] Total swap = 0kB
[   89.699486] 8192 pages RAM
[   89.716566] 0 pages HighMem/MovableOnly
[   89.734524] 2367 pages reserved
[   89.751399] Tasks state (memory values in pages):
[   89.769880] [  pid  ]   uid  tgid total_vm      rss pgtables_bytes swapents oom_score_adj name
[   89.792619] [     54]     0    54      702       20     8192        0             0 syslogd
[   89.815044] [     58]     0    58      702       20     6144        0             0 klogd
[   89.836944] [     77]     0    77      702       28     8192        0             0 sh
[   89.858256] [     86]     0    86   765877     2653   776192        0             0 usbip_crashes_e
[   89.892969] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),task=usbip_crashes_e,pid=86,uid=0
[   89.915644] Out of memory: Killed process 86 (usbip_crashes_e) total-vm:3063508kB, anon-rss:10576kB, file-rss:36kB, shmem-rss:0kB, UID:0 pgtables:758kB oom_score_adj:0
[   90.012199] oom_reaper: reaped process 86 (usbip_crashes_e), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
Killed
# ./usbip_bandaid_fix_185a0879a83736314c541bfd98a1f1f4b6c0d09a list -l
usbip: error: failed to open /usr/share/hwdata/usb.ids
 - busid 1-1 (1e3d:2095)
   unknown vendor : unknown product (1e3d:2095)
 
# ./usbip_refactor_fix_c803d022ef6e619546079afe20f468f82e3b27c7 list -l
usbip: error: failed to open /usr/share/hwdata/usb.ids
 - busid 1-1 (1e3d:2095)
   unknown vendor : unknown product (1e3d:2095)

# time ./usbip_refactor_fix_c803d022ef6e619546079afe20f468f82e3b27c7 list -l
usbip: error: failed to open /usr/share/hwdata/usb.ids
 - busid 1-1 (1e3d:2095)
   unknown vendor : unknown product (1e3d:2095)

real    0m 0.70s
user    0m 0.30s
sys     0m 0.39s
#
```