### PR TITLE
README: update link to PipeWire patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Keep in mind that libudev-zero isn't ideal. Here are some pros/cons:
 * android-tools - requires udev rules for non-root usage
 * NetworkManager - needs investigation
 * libgudev - needs investigation
-* PipeWire - depends on udev internal properties. [patch](https://github.com/illiliti/libudev-zero/issues/26#issuecomment-846858706)
+* PipeWire - depends on udev internal properties. [patch](https://github.com/illiliti/libudev-zero/issues/26#issuecomment-1848802791)
 * ldm - depends on udev internal properties
 * lvm2 - uses deprecated `udev_queue` API
 * cups - needs investigation


### PR DESCRIPTION
The link referred to the v1 patch but v3 is the newest.