### PR TITLE
add SOUND_INITIALIZED property and pipewire fix

### DIFF
--- a/udev_enumerate.c
+++ b/udev_enumerate.c
@@ -225,7 +225,7 @@ static int filter_sysattr(struct udev_enumerate *udev_enumerate, struct udev_dev
 
 static void add_device(struct udev_enumerate *udev_enumerate, const char *path)
 {
-    struct udev_device *udev_device;
+    struct udev_device *udev_device, *parent;
 
     udev_device = udev_device_new_from_syspath(udev_enumerate->udev, path);
 
@@ -241,6 +241,8 @@ static void add_device(struct udev_enumerate *udev_enumerate, const char *path)
         return;
     }
 
+    if ((parent = udev_device_get_parent(udev_device)))
+        udev_list_entry_add(&udev_enumerate->devices, udev_device_get_syspath(parent), NULL, 0);
     udev_list_entry_add(&udev_enumerate->devices, udev_device_get_syspath(udev_device), NULL, 0);
 
     udev_device_unref(udev_device);


### PR DESCRIPTION
Adds the SOUND_INITIALIZED property Pipewire looks for when adding sound cards and re-reverts (everts?) https://github.com/illiliti/libudev-zero/commit/4510b27a9b589a0ce82fef776c2648e19e79f2a4 so it can find `card[0-9]`.

Fixes #26 without patching Pipewire.

- [ ] Should `scan_devices` be rewritten so it starts its search at `/sys/class/sound`? Adding the parent in `add_device` feels weird.