### PR TITLE
RFC: propose helper script interface for writing rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,14 @@
 
 PREFIX = /usr/local
 LIBDIR = ${PREFIX}/lib
+LIBEXECDIR = ${PREFIX}/libexec
 INCLUDEDIR = ${PREFIX}/include
 PKGCONFIGDIR = ${LIBDIR}/pkgconfig
-XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -fPIC -D_XOPEN_SOURCE=700 \
+RULES_HELPER_PATH = ${LIBEXECDIR}/libudev-zero-rules-helper
+XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -fPIC -D_GNU_SOURCE \
 		  -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wstrict-prototypes \
-		  -Wno-unused-parameter
+		  -Wno-unused-parameter \
+		  -DRULES_HELPER_PATH=\"${RULES_HELPER_PATH}\"
 XLDFLAGS = ${LDFLAGS} -shared -Wl,-soname,libudev.so.1
 XARFLAGS = -rc
 AR = ar

--- a/contrib/libudev-zero-rules-helper.sh
+++ b/contrib/libudev-zero-rules-helper.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+if [ "$SUBSYSTEM" = "sound" ]
+then
+    if printf '%s' "$SYSNAME" | grep '^card' > /dev/null
+    then
+        printf 'SOUND_INITIALIZED=1\n'
+    fi
+
+    if printf '%s' "$SYSNAME" | grep '^pcmC.*D2c$' > /dev/null \
+        && grep '^AppleJ' "$SYSPATH/device/id" 2>/dev/null
+    then
+        printf 'ACP_IGNORE=1\n'
+    fi
+fi


### PR DESCRIPTION
Proposes the use of a helper script to allow setting udev properties as a replacement for udev rules.  For example setting `ACP_IGNORE=1` on the visense pcm in apple silicon macs.
```sh
#!/bin/sh -e

if printf '%s\n' "$SYSNAME" | grep '^pcmC.*D2c$'
then
	printf 'ACP_IGNORE=1\n'
fi
```